### PR TITLE
Suggest using :path: not :root-path: if no workspace was defined

### DIFF
--- a/sphinxcontrib/sphinx_bazel/autobazel/common.py
+++ b/sphinxcontrib/sphinx_bazel/autobazel/common.py
@@ -77,7 +77,7 @@ class AutobazelCommonDirective(Directive):
                     self.log.error("No workspace was defined before the {} definition of {}.\n "
                                    "Please define one, which can than be used as reference for "
                                    "calculating file paths.\n"
-                                   "Or use option :root-path: to document something without"
+                                   "Or use option :path: to document something without"
                                    "a bazel workspace.".format(self.name, self.arguments[0]))
                     return []
 


### PR DESCRIPTION
Currently, the error message suggests using the `:root-path:` option to temporarily set the workspace path; however, this option does not exist. The error message should instead suggest using the `:path:` option.